### PR TITLE
Fix scrollbar width calculation for iframe

### DIFF
--- a/packages/simplebar/src/scrollbar-width.js
+++ b/packages/simplebar/src/scrollbar-width.js
@@ -1,4 +1,5 @@
 import canUseDOM from 'can-use-dom';
+import { getElementDocument } from "./helpers";
 
 let cachedScrollbarWidth = null;
 let cachedDevicePixelRatio = null;
@@ -18,7 +19,7 @@ export default function scrollbarWidth() {
       cachedScrollbarWidth = 0;
       return cachedScrollbarWidth;
     }
-
+    const document = getElementDocument();
     const body = document.body;
     const box = document.createElement('div');
 


### PR DESCRIPTION
This fix will get actual document object to calculate width of native scrollbars. This resolves bug when simplebar is used inside iframe